### PR TITLE
libopus 1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://archive.mozilla.org/pub/opus/opus-{{ version }}.1.tar.gz
   sha256: 65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
   run_exports:
     # seems to be maintaining compatibility across minor versions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,17 +31,23 @@ requirements:
     - m2w64-gcc-libs            # [win]
 
 test:
+  requires:
+    - conda-build
   commands:
     - test -f ${PREFIX}/lib/libopus.a              # [not win]
     - test -f ${PREFIX}/lib/libopus.so             # [linux]
     - test -f ${PREFIX}/lib/libopus.dylib          # [osx]
     - conda inspect linkages -p $PREFIX libopus   # [not win]
     - conda inspect objects -p $PREFIX libopus    # [osx]
+  downstreams:
+    - ffmpeg
+    - gst-plugins-base
 
 about:
-  home: http://opus-codec.org/
-  license: 3-clause BSD
+  home: https://opus-codec.org/
+  license: BSD-3-Clause
   license_family: BSD
+  license_file: COPYING
   summary: Opus Interactive Audio Codec
   description: |
     Opus is a totally open, royalty-free, highly versatile
@@ -51,5 +57,5 @@ about:
     standardized by the Internet Engineering Task Force
     (IETF) as RFC 6716 which incorporated technology from
     Skype's SILK codec and Xiph.Org's CELT codec.
-  doc_url: http://opus-codec.org/docs/
-  dev_url: http://opus-codec.org/development/
+  doc_url: https://opus-codec.org/docs/
+  dev_url: https://opus-codec.org/development/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,6 @@ test:
     - test -f ${PREFIX}/lib/libopus.dylib          # [osx]
     - conda inspect linkages -p $PREFIX libopus   # [not win]
     - conda inspect objects -p $PREFIX libopus    # [osx]
-  downstreams:
-    - ffmpeg
-    - gst-plugins-base
 
 about:
   home: https://opus-codec.org/


### PR DESCRIPTION
libopus 1.3 rebuild

**Destination channel:** defaults

### Links

- [PKG-5828](https://anaconda.atlassian.net/browse/PKG-5828) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/libsndfile-feedstock/pull/2
  - https://github.com/AnacondaRecipes/pysoundfile-feedstock/pull/1
  - https://github.com/AnacondaRecipes/wfdb-feedstock/pull/1

wfdb <- pysoundfile <- libsndfile <- libopus

### Explanation of changes:

-  `linux aarch64` `libopus` had a package config file that had an unknown version in it. When `libsndfile` was being compiled, it had a "all or nothing" check and silently removed all of `libopus, libflak, ect` Which caused `libsndfile` on `linux aarch64` to be built incorrectly, along with `pysoundfile` and `wfdb`.

- added `downstreams` section to ensure other dependencies would not be effected. Will remove once approved.


[PKG-5828]: https://anaconda.atlassian.net/browse/PKG-5828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ