### PR TITLE
libopus 1.3.1 [rebuild]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3" %}
+{% set version = "1.3.1" %}
 {% set p = "m2-" if win else "" %}
 
 package:
@@ -6,10 +6,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://archive.mozilla.org/pub/opus/opus-{{ version }}.1.tar.gz
+  url: https://archive.mozilla.org/pub/opus/opus-{{ version }}.tar.gz
   sha256: 65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d
 build:
-  number: 2
+  number: 1
   skip: True  # [win]
   run_exports:
     # seems to be maintaining compatibility across minor versions


### PR DESCRIPTION
libopus 1.3.1

**Destination channel:** defaults

### Links

- [PKG-5878]
- see previous PR #1 

### Explanation of changes:

- fix version, bump build number to 1 +EDIT: because on some platforms is already present with 0+
- the source tarball is the same, the version 1.3 was mistakenly published with 1.3.1 sources, now releasing 1.3.1

### Dependency for

- https://github.com/AnacondaRecipes/libsndfile-feedstock/pull/3

### Notes

```
for p in linux-{64,s390x,aarch64} win-64 osx-{64,arm64}; do echo -e "*** $p"; conda search -q --platform=$p "libopus" -c main --override-channels; echo ""; done

*** linux-64
Loading channels: ...working... done
# Name                       Version           Build  Channel
libopus                        1.2.1      hb9ed12e_0  main
libopus                          1.3      h5eee18b_2  main
libopus                          1.3      h7b6447c_0  main
libopus                        1.3.1      h7b6447c_0  main

*** linux-s390x
Loading channels: ...working... done
# Name                       Version           Build  Channel
libopus                          1.3      h2a837d6_1  main
libopus                          1.3      hc33a586_2  main

*** linux-aarch64
Loading channels: ...working... done
# Name                       Version           Build  Channel
libopus                          1.3      h998d150_2  main
libopus                        1.3.1      h2f4d8fa_0  main

*** win-64
Loading channels: ...working... done
No match found for: libopus. Search: *libopus*

PackagesNotFoundError: The following packages are not available from current channels:

*** osx-64
Loading channels: ...working... done
# Name                       Version           Build  Channel
libopus                        1.2.1      h169cedb_0  main
libopus                          1.3      h1de35cc_0  main
libopus                          1.3      h46256e1_2  main
libopus                        1.3.1      h1de35cc_0  main

*** osx-arm64
Loading channels: ...working... done
# Name                       Version           Build  Channel
libopus                          1.3      h1a28f6b_1  main
libopus                          1.3      h80987f9_2  main

```


[PKG-5878]: https://anaconda.atlassian.net/browse/PKG-5878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ