### PR TITLE
libopus 1.6.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,19 @@
+mkdir build
+cd build
+if errorlevel 1 exit /b 1
+
+echo "PACKAGE_VERSION=%PKG_VERSION%" > %SRC_DIR%\package_version
+if errorlevel 1 exit /b 1
+
+cmake -G "Ninja" ^
+	-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+	-DBUILD_SHARED_LIBS=ON ^
+	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+	-DCMAKE_BUILD_TYPE=Release ^
+	%CMAKE_ARGS% ^
+	%SRC_DIR%
+
+if errorlevel 1 exit /b 1
+
+ninja install
+if errorlevel 1 exit /b 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
 
-# Get an updated config.sub and config.guess
-cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* .
+echo "PACKAGE_VERSION=${PKG_VERSION}" > package_version
 
-if [[ $(uname) == MSYS* ]]; then
-  if [[ ${ARCH} == 32 ]]; then
-    HOST_BUILD="--host=i686-w64-mingw32 --build=i686-w64-mingw32"
-  else
-    HOST_BUILD="--host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32"
-  fi
-  PREFIX=${PREFIX}/Library/mingw-w64
-  JOBS=${NUMBER_OF_PROCESSORS}
-elif [[ $(uname) == Darwin ]]; then
-  JOBS=$(sysctl -n hw.ncpu)
-else
-  JOBS=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1)
-fi
+./autogen.sh
 
-# ./autogen.sh
-./configure --prefix=${PREFIX} ${HOST_BUILD} && make -j${JOBS} && make install
+./configure --prefix=${PREFIX} --disable-static --disable-doc
+
+make -j${CPU_COUNT}
+
+make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "1.3.1" %}
-{% set p = "m2-" if win else "" %}
+{% set name = "libopus" %}
+{% set version = "1.6.1" %}
 
 package:
-  name: libopus
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://archive.mozilla.org/pub/opus/opus-{{ version }}.tar.gz
-  sha256: 65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d
+  url: https://github.com/xiph/opus/archive/v{{ version }}.tar.gz
+  sha256: bf0b97ec7a65890b8db90ef94c4d6c18de12584c3085031953a10986f5917745
+
 build:
-  number: 1
-  skip: True  # [win]
+  number: 0
   run_exports:
     # seems to be maintaining compatibility across minor versions
     # https://abi-laboratory.pro/tracker/timeline/opus/
@@ -18,30 +18,29 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - posix                     # [win]
-    - git
-    - {{ p }}make
-    - {{ p }}autoconf
-    - {{ p }}libtool
-    - {{ p }}automake           # [not win]
-    - {{ p }}automake-wrapper   # [win]
-    - m2w64-toolchain           # [win]
-  run:
-    - m2w64-gcc-libs            # [win]
+    - make        # [unix]
+    - autoconf    # [unix]
+    - libtool     # [unix]
+    - automake    # [unix]
+    - wget        # [unix]
+    - cmake       # [win]
+    - ninja-base  # [win]
 
 test:
   requires:
     - conda-build
   commands:
-    - test -f ${PREFIX}/lib/libopus.a              # [not win]
-    - test -f ${PREFIX}/lib/libopus.so             # [linux]
-    - test -f ${PREFIX}/lib/libopus.dylib          # [osx]
-    - conda inspect linkages -p $PREFIX libopus   # [not win]
-    - conda inspect objects -p $PREFIX libopus    # [osx]
+    - test ! -f ${PREFIX}/lib/libopus.a            # [unix]
+    - test -f ${PREFIX}/lib/libopus${SHLIB_EXT}    # [unix]
+    - if not exist %LIBRARY_BIN%\opus.dll exit 1   # [win]
+    - if not exist %LIBRARY_LIB%\opus.lib exit 1   # [win]
+    - conda inspect linkages -p $PREFIX libopus    # [unix]
+    - conda inspect objects -p $PREFIX libopus     # [osx]
 
 about:
-  home: https://opus-codec.org/
+  home: https://opus-codec.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: COPYING
@@ -54,5 +53,5 @@ about:
     standardized by the Internet Engineering Task Force
     (IETF) as RFC 6716 which incorporated technology from
     Skype's SILK codec and Xiph.Org's CELT codec.
-  doc_url: https://opus-codec.org/docs/
-  dev_url: https://opus-codec.org/development/
+  doc_url: https://opus-codec.org/docs
+  dev_url: https://opus-codec.org/development


### PR DESCRIPTION
libopus 1.6.1

**Destination channel:** Defaults

### Links

- [PKG-11610]
- dev_url:        https://gitlab.xiph.org/xiph/opus/-/tree/v1.6.1?ref_type=tags
- conda_forge:    https://github.com/conda-forge/libopus-feedstock
- pypi:
- pypi inspector:

### Explanation of changes:

- new version number


[PKG-11610]: https://anaconda.atlassian.net/browse/PKG-11610